### PR TITLE
Raise exception on missing augeasproviders_core

### DIFF
--- a/lib/puppet/provider/mounttab/augeas.rb
+++ b/lib/puppet/provider/mounttab/augeas.rb
@@ -13,6 +13,7 @@
 require File.dirname(__FILE__) + '/../../../augeasproviders/mounttab/fstab'
 require File.dirname(__FILE__) + '/../../../augeasproviders/mounttab/vfstab'
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:mounttab).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update the /etc/(v)fstab file"
 


### PR DESCRIPTION
People who manage their code with r10k have to resolve dependencies by
hand (or using a generator), as such we now helpfully raise an exception
when miaugeasproviders_core is missing.